### PR TITLE
fix: add missing shebang for bin/ensure-venv

### DIFF
--- a/bin/ensure-venv
+++ b/bin/ensure-venv
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #####
 # This script creates a virtualenv and installs the required dependencies
 #####


### PR DESCRIPTION
When running through the documentation to connect to the cluster, I found a bug in the `ensure-venv` script - the line which determines the Azimuth root config will only work with bash

As I was using zsh, and the script has no shebang, this was failing. This Pull request adds a shebang for bash at the top of the script to prevent this issue (you can also call the script directly with `bash ./bin/ensure-venv` but this is not what is the in [the documentation](https://azimuth-config.readthedocs.io/en/stable/debugging/access-k3s/))